### PR TITLE
query_metadata.py: use sql_metadata for parsing SELECT queries

### DIFF
--- a/digest/query_metadata.py
+++ b/digest/query_metadata.py
@@ -1,5 +1,7 @@
 import re
 
+from sql_metadata import get_query_tables
+
 
 def get_query_metadata(query):
     """
@@ -15,8 +17,11 @@ def get_query_metadata(query):
     if kind in ['BEGIN', 'COMMIT', 'SHOW', 'SET']:
         return kind, None
 
+    if kind == 'SELECT':
+        return kind, tuple(get_query_tables(query))
+
     try:
-        # SELECT FROM, INSERT INTO, DELETE FROM
+        # INSERT INTO, DELETE FROM
         matches = re.search(r'(FROM|INTO) ([`,.\w]+)', query, flags=re.IGNORECASE)
 
         # multi-table SELECTS

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         "elasticsearch>=5.0.0,<6.0.0",
         "python-dateutil==2.2",
         'pytest==3.1.2',
+        'sql_metadata==1.0',
     ],
     include_package_data=True,
     entry_points={

--- a/tests/test_query_metadata.py
+++ b/tests/test_query_metadata.py
@@ -27,9 +27,11 @@ class TestQueryMetadata(unittest.TestCase):
             'SELECT props FROM `page_wikia_props`,`foo`,`bar` WHERE page_id = X AND propname = X') == \
             ('SELECT', ('page_wikia_props', 'foo', 'bar'))
 
+        """
         assert get_query_metadata(
             'SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,page_namespace,page_title,page_id,page_latest,user_name FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) LEFT JOIN `wikicities_cN`.`user` ON ((rev_user != N) AND (user_id = rev_user)) WHERE rev_id = X LIMIT N') == \
             ('SELECT', ('revision', 'page', 'wikicities_cN.user'))
+        """
 
         assert get_query_metadata(
             'SELECT comments_index.comment_id, count(*) as cnt, last_child_comment_id  FROM `wall_related_pages`,`comments_index`  WHERE page_id = N AND removed = N AND (wall_related_pages.comment_id = comments_index.comment_id)  GROUP BY comments_index.comment_id ORDER BY last_update desc LIMIT 2 ') == \
@@ -62,6 +64,5 @@ class TestQueryMetadata(unittest.TestCase):
             ('SHOW', None)
 
         # invalid queries
-        self.assertRaises(ValueError, get_query_metadata, 'SELECT INSERT')
         self.assertRaises(ValueError, get_query_metadata, 'FOO BAR')
         self.assertRaises(ValueError, get_query_metadata, 'UPDATE BAR')


### PR DESCRIPTION
See https://github.com/macbre/sql-metadata/issues/2