### PR TITLE
digest/queries.py: fetch required fields only

### DIFF
--- a/digest/queries.py
+++ b/digest/queries.py
@@ -10,6 +10,8 @@ from wikia_common_kibana import Kibana
 
 from .helpers import generalize_sql, remove_comments_from_sql
 
+QUERIES_LIMIT = 50000
+
 
 def get_log_entries(query, period, fields, limit, index_prefix='logstash-other'):
     """
@@ -30,7 +32,7 @@ def get_log_entries(query, period, fields, limit, index_prefix='logstash-other')
     return source.query_by_string(query, fields, limit)
 
 
-def get_sql_queries_by_path(path, limit=500000, period=3600):
+def get_sql_queries_by_path(path, limit=QUERIES_LIMIT, period=3600):
     """
     Get MediaWiki SQL queries made in the last hour from a given code path
 
@@ -60,7 +62,7 @@ def get_sql_queries_by_path(path, limit=500000, period=3600):
     return tuple(map(normalize_mediawiki_entry, entries))
 
 
-def get_sql_queries_by_table(table, limit=500000, period=3600):
+def get_sql_queries_by_table(table, limit=QUERIES_LIMIT, period=3600):
     """
     Get MediaWiki SQL queries made in the last hour affecting given table
 
@@ -90,7 +92,7 @@ def get_sql_queries_by_table(table, limit=500000, period=3600):
     return tuple(map(normalize_mediawiki_entry, entries))
 
 
-def get_backend_queries_by_table(table, limit=500000, period=3600):
+def get_backend_queries_by_table(table, limit=QUERIES_LIMIT, period=3600):
     """
     Get Perl backend SQL queries made in the last hour affecting given table
 
@@ -118,7 +120,7 @@ def get_backend_queries_by_table(table, limit=500000, period=3600):
     return tuple(map(normalize_backend_entry, entries))
 
 
-def get_sql_queries_by_database(database, limit=500000, period=3600):
+def get_sql_queries_by_database(database, limit=QUERIES_LIMIT, period=3600):
     """
     Get MediaWiki SQL queries made in the last hour affecting given database
 
@@ -148,7 +150,7 @@ def get_sql_queries_by_database(database, limit=500000, period=3600):
     return tuple(map(normalize_mediawiki_entry, entries))
 
 
-def get_backend_queries_by_database(database, limit=500000, period=3600):
+def get_backend_queries_by_database(database, limit=QUERIES_LIMIT, period=3600):
     """
     Get Perl backend SQL queries made in the last hour affecting given database
 

--- a/scripts/query_digest.py
+++ b/scripts/query_digest.py
@@ -184,7 +184,10 @@ def main():
     elif sql_log_output:
         print('-- {}'.format(report_header))
         stdout.writelines([
-            '/* {} */ {}\n'.format(entry.get('method'), entry.get('original_query', '').replace("\n", ' ').encode('utf-8')) for entry in data
+            '/* {} */ {}\n'.format(
+                entry.get('method'),
+                entry.get('original_query', '').replace("\n", ' ').encode('utf-8')
+            ) for entry in data
         ])
     else:
         # @see https://pypi.python.org/pypi/tabulate

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'docopt==0.6.2',
         'tabulate==0.8.2',
-        'wikia-common-kibana==2.2.4',
+        'wikia-common-kibana==2.2.5',
         'sql_metadata==1.1.2',
     ],
     extras_require={


### PR DESCRIPTION
And fetch up to 50k rows from elastic (instead of 500k)